### PR TITLE
필요없는 로직 변경

### DIFF
--- a/src/main/java/util/HeaderUtil.java
+++ b/src/main/java/util/HeaderUtil.java
@@ -52,7 +52,7 @@ public class HeaderUtil {
         int index = param.indexOf("=");
         if(index > -1) {
             String key = param.substring(0, index);
-            String value = param.substring(index + 1);
+            String value = param.substring(index + 2);
 
             paramMap.put(key, value);
         }

--- a/src/main/java/util/HeaderUtil.java
+++ b/src/main/java/util/HeaderUtil.java
@@ -52,7 +52,7 @@ public class HeaderUtil {
         int index = param.indexOf("=");
         if(index > -1) {
             String key = param.substring(0, index);
-            String value = param.substring(index + 1, param.length());
+            String value = param.substring(index + 1);
 
             paramMap.put(key, value);
         }

--- a/src/main/java/util/HeaderUtil.java
+++ b/src/main/java/util/HeaderUtil.java
@@ -52,7 +52,7 @@ public class HeaderUtil {
         int index = param.indexOf("=");
         if(index > -1) {
             String key = param.substring(0, index);
-            String value = param.substring(index + 2);
+            String value = param.substring(index + 1);
 
             paramMap.put(key, value);
         }


### PR DESCRIPTION
필요없는 로직 변경
- aram.substring 메서드는 파라미터 하나일 때 맨 끝까지 서브스트링을 만드므로 필요없기에 제거